### PR TITLE
we change how we deal with sourceAnchor in includedFile

### DIFF
--- a/src/Carrefour-Esope/FamixEsopeSegment.extension.st
+++ b/src/Carrefour-Esope/FamixEsopeSegment.extension.st
@@ -26,15 +26,15 @@ FamixEsopeSegment >> bindFastModel: fastModel [
 { #category : '*Carrefour-Esope' }
 FamixEsopeSegment >> importFASTModel [
 
-	| fortranCode tempModel segmentSource |
+	| fortranCode tempModel |
 	self assert: self sourceAnchor isNotNil.
 	
-	segmentSource := 'c@_   ', self sourceAnchor sourceText.
+	sourceAnchor endLine: sourceAnchor endLine + 1.
 
 	fortranCode := String streamContents:  [  :aStream | 
 		FortranProjectImporter new 
-			writeFakeEsopeProgramUnit: 'fakesubroutine' 
-			from: segmentSource
+			writeFakeEsopeProgramUnit: self name 
+			from: self sourceAnchor sourceText
 			on: aStream
 	].
 


### PR DESCRIPTION
(in Esope project with commit_id  d217ed7)

we do not to add 'c@_    ' anymore
and we chose to use the name of the entity (self) as name of the fake subroutine